### PR TITLE
fixed - web components work correctly on production builds

### DIFF
--- a/src/components/conduct.js
+++ b/src/components/conduct.js
@@ -1,15 +1,13 @@
-import React from "react"
-
-if (typeof HTMLElement !== "undefined") {
-	require("@wpcampus/wpcampus-wc-conduct")
-}
+import React, { useEffect } from "react"
 
 import "./../css/conduct.css"
 
 const Conduct = () => {
-	return (
-		<wpcampus-conduct></wpcampus-conduct>
-	)
+	useEffect(() => {
+		import('@wpcampus/wpcampus-wc-conduct')
+	}, [])
+
+	return <wpcampus-conduct></wpcampus-conduct>
 }
 
 export default Conduct

--- a/src/components/conduct.js
+++ b/src/components/conduct.js
@@ -4,7 +4,7 @@ import "./../css/conduct.css"
 
 const Conduct = () => {
 	useEffect(() => {
-		import('@wpcampus/wpcampus-wc-conduct')
+		require("@wpcampus/wpcampus-wc-conduct")
 	}, [])
 
 	return <wpcampus-conduct></wpcampus-conduct>

--- a/src/components/conduct.js
+++ b/src/components/conduct.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useMemo } from "react"
 
 import "./../css/conduct.css"
 
@@ -7,7 +7,9 @@ const Conduct = () => {
 		require("@wpcampus/wpcampus-wc-conduct")
 	}, [])
 
-	return <wpcampus-conduct></wpcampus-conduct>
+	return useMemo(() => {
+		return <wpcampus-conduct></wpcampus-conduct>
+	})
 }
 
 export default Conduct

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useMemo } from "react"
 
 import "./../css/footer.css"
 
@@ -7,7 +7,9 @@ const Footer = () => {
 		require("@wpcampus/wpcampus-wc-footer")
 	}, [])
 
-	return <wpcampus-footer></wpcampus-footer>
+	return useMemo(() => {
+		return <wpcampus-footer></wpcampus-footer>
+	})
 }
 
 export default Footer

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -4,7 +4,7 @@ import "./../css/footer.css"
 
 const Footer = () => {
 	useEffect(() => {
-		import('@wpcampus/wpcampus-wc-footer')
+		require("@wpcampus/wpcampus-wc-footer")
 	}, [])
 
 	return <wpcampus-footer></wpcampus-footer>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,15 +1,13 @@
-import React from "react"
-
-if (typeof HTMLElement !== "undefined") {
-	require("@wpcampus/wpcampus-wc-footer")
-}
+import React, { useEffect } from "react"
 
 import "./../css/footer.css"
 
 const Footer = () => {
-	return (
-		<wpcampus-footer></wpcampus-footer>
-	)
+	useEffect(() => {
+		import('@wpcampus/wpcampus-wc-footer')
+	}, [])
+
+	return <wpcampus-footer></wpcampus-footer>
 }
 
 export default Footer

--- a/src/components/notifications.js
+++ b/src/components/notifications.js
@@ -1,15 +1,15 @@
-import React from "react"
-
-if (typeof HTMLElement !== "undefined") {
-	require("@wpcampus/wpcampus-wc-notifications")
-}
+import React, { useEffect, useMemo } from "react"
 
 import "../css/notifications.css"
 
 const Notifications = () => {
-	return (
-		<wpcampus-notifications></wpcampus-notifications>
-	)
+	useEffect(() => {
+		require("@wpcampus/wpcampus-wc-notifications")
+	}, [])
+
+	return useMemo(() => {
+		return <wpcampus-notifications></wpcampus-notifications>
+	})
 }
 
 export default Notifications

--- a/src/components/sidebar.js
+++ b/src/components/sidebar.js
@@ -1,13 +1,9 @@
-import React from "react"
+import React, { useEffect, useMemo } from "react"
 import PropTypes from "prop-types"
 import { Link } from "gatsby"
 
 import QuotesIcon from "../svg/quotes"
 import TwitterIcon from "../svg/twitter"
-
-if (typeof HTMLElement !== "undefined") {
-	require("@wpcampus/wpcampus-wc-blog")
-}
 
 import "./../css/sidebar.css"
 
@@ -30,10 +26,15 @@ Widget.propTypes = {
 }
 
 const BlogWidget = () => {
-	return <Widget type="blog">
-		<h2 className="wpc-widget__heading"><Link className="wpc-icon-text" aria-label="The WPCampus Blog" to="/blog"><QuotesIcon />From our blog</Link></h2>
-		<wpcampus-blog></wpcampus-blog>
-	</Widget>
+	useEffect(() => {
+		require("@wpcampus/wpcampus-wc-blog")
+	}, [])
+	return useMemo(() => {
+		return <Widget type="blog">
+			<h2 className="wpc-widget__heading"><Link className="wpc-icon-text" aria-label="The WPCampus Blog" to="/blog"><QuotesIcon />From our blog</Link></h2>
+			<wpcampus-blog></wpcampus-blog>
+		</Widget>
+	})
 }
 
 // @TODO replace with web component.

--- a/src/templates/library.js
+++ b/src/templates/library.js
@@ -1,22 +1,23 @@
-import React from "react"
+import React, { useEffect, useMemo } from "react"
 import { graphql } from "gatsby"
 import PropTypes from "prop-types"
 import ReactHtmlParser from "react-html-parser"
 
 import Layout from "../components/layout"
 
-if (typeof HTMLElement !== "undefined") {
-	require("@wpcampus/wpcampus-wc-library")
-}
-
 const Library = props => {
 	const page = props.data.wordpressPage
-	return (
-		<Layout heading={page.title} path={props.path}>
+
+	useEffect(() => {
+		require("@wpcampus/wpcampus-wc-library")
+	}, [])
+
+	return useMemo(() => {
+		return <Layout heading={page.title} path={props.path}>
 			<div>{ReactHtmlParser(page.content)}</div>
 			<wpcampus-library></wpcampus-library>
 		</Layout>
-	)
+	})
 }
 
 Library.propTypes = {


### PR DESCRIPTION
web components were not loading correctly during production builds. they would not be visible when the site loads initially. only after navigating to a new page would they render correctly.

this pr resolves that issue by importing the components during react's `useEffect` hook as per [this gatsby issue](https://github.com/gatsbyjs/gatsby/issues/16815).

NB - my linter shows the following `Parsing error: 'import' and 'export' may only appear at the top level`. this approach still works, but we may need a different pr to adjust the linter