### PR TITLE
small tweak to describe dev and prod env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Run `npm run css` in the command line.
 
 ## WPCampus setup
 
-1. Duplicate the .env.sample file and rename as .env.development.
+1. Duplicate the .env.sample twice with the following names. These files are used depending on the environment being run.
+	* .env.development
+	* .env.production
 2. Set the data for your dev environment.
     * [Talk to an administrator](./.github/CODEOWNERS) for the correct information.
 3. Add `WPC_SHOW_GRID=1` to .env.development to display CSS grid in development environment.


### PR DESCRIPTION
when I tried to run `npm run serve` it was initially unclear that I needed `.env.production` file in addition to the `.env.development` file. this adjusts the readme to clarify