### PR TITLE
Changing environment variables and enabling dev URLs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 WPC_WORDPRESS={Domain of WordPress application without the protocol, no trailing slash}
 WPC_API={Domain of WordPress JSON prefix (/wp-json) with protocol, no trailing slash}
-WPC_SITE={Domain of public-facing, headless website URL with protocol, no trailing slash}
+WPC_PUBLIC={Domain of public-facing, headless website URL with protocol, no trailing slash}
 WPC_JWT_USER={Your WordPress account user name. Your account has to have minimum permissions.}
 WPC_JWT_PASSWORD={Your WordPress account password. Your account has to have minimum permissions.}
 WPC_GF_API_USER=

--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,6 @@
 WPC_APP={Domain of WordPress application without the protocol, no trailing slash}
 WPC_API={Domain of WordPress JSON prefix (/wp-json) with protocol, no trailing slash}
+WPC_SITE={Domain of public-facing, headless website URL with protocol, no trailing slash}
 WPC_JWT_USER=
 WPC_JWT_PASSWORD=
 WPC_GF_API_USER=

--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-WPC_APP={Domain of WordPress application without the protocol, no trailing slash}
+WPC_WORDPRESS={Domain of WordPress application without the protocol, no trailing slash}
 WPC_API={Domain of WordPress JSON prefix (/wp-json) with protocol, no trailing slash}
 WPC_SITE={Domain of public-facing, headless website URL with protocol, no trailing slash}
 WPC_JWT_USER={Your WordPress account user name. Your account has to have minimum permissions.}

--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-WPC_HOST=
+WPC_APP={Domain of WordPress application without the protocol, no trailing slash}
 WPC_JWT_USER=
 WPC_JWT_PASSWORD=
 WPC_GF_API_USER=

--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,8 @@
 WPC_APP={Domain of WordPress application without the protocol, no trailing slash}
 WPC_API={Domain of WordPress JSON prefix (/wp-json) with protocol, no trailing slash}
 WPC_SITE={Domain of public-facing, headless website URL with protocol, no trailing slash}
-WPC_JWT_USER=
-WPC_JWT_PASSWORD=
+WPC_JWT_USER={Your WordPress account user name. Your account has to have minimum permissions.}
+WPC_JWT_PASSWORD={Your WordPress account password. Your account has to have minimum permissions.}
 WPC_GF_API_USER=
 WPC_GF_API_PASSWORD=
 WPC_GF_API_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 WPC_APP={Domain of WordPress application without the protocol, no trailing slash}
+WPC_API={Domain of WordPress JSON prefix (/wp-json) with protocol, no trailing slash}
 WPC_JWT_USER=
 WPC_JWT_PASSWORD=
 WPC_GF_API_USER=

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Run `npm run css` in the command line.
 	* .env.development
 	* .env.production
 2. Set the data for your dev environment.
-    * [Talk to an administrator](./.github/CODEOWNERS) for the correct information.
+	* Descriptions are included in the .env.sample file.
+    * For more info or assistance, [talk to an administrator](./.github/CODEOWNERS).
 3. Add `WPC_SHOW_GRID=1` to .env.development to display CSS grid in development environment.
 
 ## Gatsby setup

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -73,7 +73,7 @@ module.exports = {
 		{
 			resolve: "gatsby-source-wordpress",
 			options: {
-				baseUrl: process.env.WPC_APP,
+				baseUrl: process.env.WPC_WORDPRESS,
 				protocol: "https",
 				hostingWPCOM: false,
 				useACF: false,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,7 @@ require("dotenv").config({
 
 module.exports = {
 	siteMetadata: {
-		siteUrl: `${process.env.WPC_SITE}/`,
+		siteUrl: `${process.env.WPC_PUBLIC}/`,
 		siteName: "WPCampus: Where WordPress Meets Higher Education",
 		description: "WPCampus is a community of web professionals, educators, and people dedicated to advancing Higher Education by providing support, resources, and training focused on open source web publishing technologies.",
 		locale: "en_US",
@@ -15,7 +15,7 @@ module.exports = {
 		{
 			resolve: "gatsby-plugin-react-helmet-canonical-urls",
 			options: {
-				siteUrl: process.env.WPC_SITE,
+				siteUrl: process.env.WPC_PUBLIC,
 			},
 		},
 		{
@@ -39,8 +39,8 @@ module.exports = {
 			resolve: "gatsby-plugin-robots-txt",
 			options: {
 				env: {
-					host: process.env.WPC_SITE,
-					sitemap: `${process.env.WPC_SITE}/sitemap.xml`,
+					host: process.env.WPC_PUBLIC,
+					sitemap: `${process.env.WPC_PUBLIC}/sitemap.xml`,
 					development: {
 						policy: [{ userAgent: "*", disallow: ["/"] }]
 					},

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -73,7 +73,7 @@ module.exports = {
 		{
 			resolve: "gatsby-source-wordpress",
 			options: {
-				baseUrl: process.env.WPC_HOST,
+				baseUrl: process.env.WPC_APP,
 				protocol: "https",
 				hostingWPCOM: false,
 				useACF: false,

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -9,6 +9,15 @@ import LibraryLayout from "./library"
 
 import MagnifyingGlass from "../svg/magnifying-glass"
 
+/*
+ * Set the search URL for search requests.
+ *
+ * Environment variables are only accessible in development.
+ */
+const isDev = "development" === process.env.NODE_ENV
+const wpcSearchRoot = isDev ? process.env.WPC_API : "https://wpcampus.org/wp-json"
+const wpcSearchURL = `${wpcSearchRoot}/wpcampus/search/`
+
 const sanitizeSearchTerm = (str) => {
 	str = str.replace(/[^a-z0-9áéíóúñü .,_-]/gim, "")
 	return str.trim()
@@ -404,7 +413,7 @@ class SearchLayout extends React.Component {
 		// @TODO doesnt need to run when component is mounted because already set?
 		window.history.pushState({}, "", "/search/" + encodedSearchStr)
 
-		let url = "https://wpcampus.org/wp-json/wpcampus/search/"
+		let url = wpcSearchURL
 
 		// What post types do we want?
 		url += "?subtype=page,post,podcast"

--- a/src/user/auth.js
+++ b/src/user/auth.js
@@ -4,8 +4,11 @@ const tokenKey = "wpc-auth-token"
 
 /*
  * Set the root URL for auth requests.
+ *
+ * Environment variables are only accessible in development.
  */
-const authRoot = "https://wpcampus.org/wp-json"
+const isDev = "development" === process.env.NODE_ENV
+const authRoot = isDev ? process.env.WPC_API : "https://wpcampus.org/wp-json"
 
 /*
  * When does authorization expire? 


### PR DESCRIPTION
Once again search and authorization will now use dev environment variables in development so our development environment can pull from the WPCampus dev WordPress app. 💯 

Changed environment variables:
- WPC_HOST to WPC_WORDPRESS to make it clearer that the variable is supposed to point to the WordPress app.
- WPC_SITE to WPC_PUBLIC to make it clearer its the URL for the public-facing Gatsby app.