### PR TITLE
Remove redundant step for making multidevs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,6 @@ workflows:
                 name: post deployment completion status
                 command: |
                  curl "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/statuses/$CIRCLE_SHA1" -H "Authorization: token $GITHUB_TOKEN" -X POST -d '{"state": "success", "context": "pantheon/deployment", "description": "Deployment complete", "target_url": "https://'${TERMINUS_ENV}'--'${TERMINUS_SITE}'.my.pantheonfrontend.website/"}'
-      - pfe/make_multidev:
-          filters:
-            branches:
-              ignore: "master"
 
 orbs:
   pfe: stevector/pantheon-frontend@0.1.0


### PR DESCRIPTION
Hi @bamadesigner, the extra step to make a multidev environment isn't needed since we have the custom Fastly config.

The custom Fastly config is responsible for environments like https://pr-22--wpcampus-gatsby.my.pantheonfrontend.website/

The extra multidev step is making environments like: https://pr-22-wpcampus-gatsby.pantheonsite.io/

Both environments are reading from the same GCP bucket but the `pantheonsite` one is slower to create and has bugs like not loading font files.
